### PR TITLE
氏名の部分検索機能を実装

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabase.test.ts
+++ b/backend-ts/src/employee/EmployeeDatabase.test.ts
@@ -1,0 +1,64 @@
+import { EmployeeDatabaseInMemory } from "./EmployeeDatabaseInMemory";
+
+describe("EmployeeDatabase", () => {
+  describe("EmployeeDatabaseInMemory", () => {
+    let db: EmployeeDatabaseInMemory;
+
+    beforeEach(() => {
+      db = new EmployeeDatabaseInMemory();
+    });
+
+    describe("getEmployees", () => {
+      test("空文字で検索すると全件取得できる", async () => {
+        const employees = await db.getEmployees("");
+        expect(employees).toHaveLength(3);
+        expect(employees.map(e => e.name)).toContain("Jane Doe");
+        expect(employees.map(e => e.name)).toContain("John Smith");
+        expect(employees.map(e => e.name)).toContain("山田 太郎");
+      });
+
+      test("部分文字列で検索できる", async () => {
+        const employees = await db.getEmployees("John");
+        expect(employees).toHaveLength(1);
+        expect(employees[0].name).toBe("John Smith");
+      });
+
+      test("日本語の部分文字列で検索できる", async () => {
+        const employees = await db.getEmployees("山田");
+        expect(employees).toHaveLength(1);
+        expect(employees[0].name).toBe("山田 太郎");
+      });
+
+      test("複数の結果が返される部分一致", async () => {
+        // Jane DoeとJohn Smithの両方が"J"を含む
+        const employees = await db.getEmployees("J");
+        expect(employees).toHaveLength(2);
+        expect(employees.map(e => e.name)).toContain("Jane Doe");
+        expect(employees.map(e => e.name)).toContain("John Smith");
+      });
+
+      test("完全一致も引き続き動作する", async () => {
+        const employees = await db.getEmployees("Jane Doe");
+        expect(employees).toHaveLength(1);
+        expect(employees[0].name).toBe("Jane Doe");
+      });
+
+      test("マッチしない文字列で検索すると0件", async () => {
+        const employees = await db.getEmployees("存在しない名前");
+        expect(employees).toHaveLength(0);
+      });
+
+      test("姓のみで検索できる", async () => {
+        const employees = await db.getEmployees("Doe");
+        expect(employees).toHaveLength(1);
+        expect(employees[0].name).toBe("Jane Doe");
+      });
+
+      test("名のみで検索できる", async () => {
+        const employees = await db.getEmployees("太郎");
+        expect(employees).toHaveLength(1);
+        expect(employees[0].name).toBe("山田 太郎");
+      });
+    });
+  });
+});

--- a/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
@@ -47,7 +47,7 @@ export class EmployeeDatabaseDynamoDB implements EmployeeDatabase {
             return [];
         }
         return items
-            .filter(item => filterText === "" || item["name"].S === filterText)
+            .filter(item => filterText === "" || item["name"].S?.includes(filterText))
             .map(item => {
                 return {
                     id: item["id"].S,

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -20,6 +20,6 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
         if (filterText === "") {
             return employees;
         }
-        return employees.filter(employee => employee.name === filterText);
+        return employees.filter(employee => employee.name.includes(filterText));
     }
 }


### PR DESCRIPTION
## 取り組みの概要

GitHub Issue #3で計画した氏名の部分検索機能を実装しました。

### 実装内容
- **DynamoDB実装**: 完全一致検索（`===`）から部分一致検索（`includes()`）に変更
- **インメモリDB実装**: 完全一致検索（`===`）から部分一致検索（`includes()`）に変更  
- **単体テスト**: 包括的なテストケースを作成し、機能の動作を保証

### 変更ファイル
- `backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts`
- `backend-ts/src/employee/EmployeeDatabaseInMemory.ts`
- `backend-ts/src/employee/EmployeeDatabase.test.ts` (新規作成)

### テストケース
- 空文字での全件取得
- 部分文字列での検索（英語・日本語）
- 複数結果の部分一致
- マッチしない文字列での0件検索
- 姓名の個別検索

## 動作確認

### 1. 単体テスト
```bash
cd backend-ts
npm test -- src/employee/EmployeeDatabase.test.ts
```
**結果**: 8つのテストケースすべてが成功（PASS）

### 2. APIテスト
バックエンドサーバーを起動し、curlコマンドでAPIの動作を確認：

```bash
# 部分一致検索（"John"で"John Smith"を検索）
curl "http://localhost:8080/api/employees?filterText=John"
→ [{"id":"2","name":"John Smith","age":28}]

# 複数結果の部分一致（"J"で"Jane Doe"と"John Smith"を検索）
curl "http://localhost:8080/api/employees?filterText=J"
→ [{"id":"1","name":"Jane Doe","age":22},{"id":"2","name":"John Smith","age":28}]

# 日本語の部分検索（"山田"で"山田 太郎"を検索）
curl "http://localhost:8080/api/employees?filterText=%E5%B1%B1%E7%94%B0"
→ [{"id":"3","name":"山田 太郎","age":27}]

# 姓での検索（"Doe"で"Jane Doe"を検索）
curl "http://localhost:8080/api/employees?filterText=Doe"
→ [{"id":"1","name":"Jane Doe","age":22}]
```

すべてのテストケースで期待通りの結果が得られ、部分検索機能が正常に動作することを確認しました。

## この改善によって得られる価値

### ユーザビリティの向上
従来の完全一致検索では、正確な氏名を覚えていないと検索できませんでした。部分検索により、以下が可能になります：
- 「田中」で「田中太郎」「田中花子」を検索
- 「John」で「John Smith」「Johnson」を検索
- 姓や名だけでの検索

### 検索効率の向上
ユーザーは少ない文字数で目的の従業員を見つけることができ、検索体験が大幅に改善されます。

### 後方互換性の維持
完全一致検索も引き続き動作するため、既存の使用パターンに影響を与えません。

🤖 Generated with [Claude Code](https://claude.ai/code)